### PR TITLE
update reason why OVN-K CNI is not supported

### DIFF
--- a/remediation/poison-pill/known-issues.md
+++ b/remediation/poison-pill/known-issues.md
@@ -14,6 +14,6 @@ Poison Pill has several known issues:
 4. Uninstalling the operator doesn't remove the poison pill daemonset. a user should delete the PoisonPillConfig CR to remove the daemonset
 5. Upon poison pill installation, it might take up to 2 minutes before the daemonset is deployed
 6. IPv6 is not supported
-7. Clusters with OVN network plugin are not supported due to [Bug 1973286](https://bugzilla.redhat.com/show_bug.cgi?id=1973286)
+7. Clusters with OVN network plugin are not supported due to [Bug 2068910](https://bugzilla.redhat.com/show_bug.cgi?id=2068910)
 8. At least two workers are required to get node fencing
 9. At release 0.3 channel name was changed from "**alpha**" to "**stable**". This means that when releases prior to 0.3 are upgraded, the channel name needs to be changed manually 


### PR DESCRIPTION
Update the bug preventing the poison-pill from working when the ovn-k CNI plugin is used.

The previous bug - [0] - was already fixed.

[0] - https://bugzilla.redhat.com/show_bug.cgi?id=1973286