### PR TITLE
Renaming master branch references to main branch

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -22,6 +22,6 @@ After few minutes, self-node-remediation will be automatically installed.
 Node Healthcheck Operator includes a dependency on [Self Node Remediation](/remediation/self-node-remediation/self-node-remediation/) with opinionated defaults to be able to function right after installation.
 You may want to tweak the configuration of both, or install one of the [alternatives to Self Node Remediation](/remediation/remediation/#implementations) in order to match your cluster needs.
 
-To tweak NHC configuration see [NHC's README](https://github.com/medik8s/node-healthcheck-operator/blob/master/docs/README.md).
+To tweak NHC's configuration see [NHC's README](https://github.com/medik8s/node-healthcheck-operator/blob/main/docs/README.md)
 
 To change the default Self Node Remediation configuration, see [Self Node Remediation Configuration](/remediation/self-node-remediation/configuration) page.

--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ last_edit_time_format: "%b %e %Y at %I:%M %p" # uses ruby's time format: https:/
 gh_edit_link: true # show or hide edit this page link
 gh_edit_link_text: "Edit this page on GitHub"
 gh_edit_repository: "https://github.com/medik8s/docs" # the github URL for your repo
-gh_edit_branch: "master" # the branch that your docs is served from
+gh_edit_branch: "gh-pages" # the branch that your docs is served from
 # gh_edit_source: docs # the source that your files originate from
 gh_edit_view_mode: "tree" # "tree" or "edit" if you want the user to jump into the editor immediately
 

--- a/faq.md
+++ b/faq.md
@@ -49,7 +49,7 @@ is a common tool for creating and updating NodeConditions based on log scraping.
 
 ## Can I create my mechanism for recovering a node?
 
-Yes.  Node Healthcheck uses the sig-cluster's [External Remediation API](https://github.com/kubernetes-sigs/cluster-api/blob/master/docs/proposals/20191030-machine-health-checking.md#external-remediation)
+Yes.  Node Healthcheck uses the sig-cluster's [External Remediation API](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20191030-machine-health-checking.md#external-remediation)
 to uniquely associate a node failure with a specific recovery mechanism of 
 your choosing. 
 
@@ -78,7 +78,7 @@ available, but also supports other mechanisms.
 
 Apart from the medik8s team being actively involved with the [Machine
 Healthcheck
-Controller](https://github.com/kubernetes-sigs/cluster-api/blob/master/controllers/machinehealthcheck_controller.go),
+Controller](https://github.com/kubernetes-sigs/cluster-api/blob/main/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go),
 the [Node Healthcheck
 Controller](https://github.com/medik8s/node-healthcheck-operator) also shares
 much of the same code.


### PR DESCRIPTION
- Renaming `master` branch references to `main` branch (Why main was chosen? see [here](https://github.com/github/renaming#why-main)).
- Adding apostrophe