### PR TITLE
Adding green GA label for NHC

### DIFF
--- a/failure_detection.md
+++ b/failure_detection.md
@@ -19,6 +19,8 @@ failure occurred. However there may be other criteria or thresholds that are
  and tolerance for risk.
 
 ## Node Healthcheck Controller
+Generally Available
+{: .label .label-green }
 
 The [Node Healthcheck Controller](https://github.com/medik8s/node-healthcheck-operator) checks each Node's set of [NodeConditions](https://kubernetes.io/docs/concepts/architecture/nodes/#condition)
 against the criteria and thresholds defined for it in [NodeHealthCheck](https://github.com/medik8s/node-healthcheck-operator#nodehealthcheck-custom-resource) CRs.


### PR DESCRIPTION
Adding Green GA label for NHC similar to SNR has (see [here](https://www.medik8s.io/remediation/self-node-remediation/self-node-remediation/)).