### PR TITLE
Add missing dependency jekyll-include-cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 gem "github-pages", "~> 215", group: :jekyll_plugins
 
 gem "just-the-docs"
+gem "jekyll-include-cache"
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,8 @@ GEM
     jekyll-github-metadata (2.13.0)
       jekyll (>= 3.4, < 5.0)
       octokit (~> 4.0, != 4.4.0)
+    jekyll-include-cache (0.2.1)
+      jekyll (>= 3.7, < 5.0)
     jekyll-mentions (1.6.0)
       html-pipeline (~> 2.3)
       jekyll (>= 3.7, < 5.0)
@@ -277,6 +279,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages (~> 215)
+  jekyll-include-cache
   just-the-docs
 
 BUNDLED WITH


### PR DESCRIPTION
Signed-off-by: Carlo Lobrano <c.lobrano@gmail.com>
