### PR TITLE
FAR Network Connectivity Limitation

### DIFF
--- a/remediation/fence-agents-remediation/fence-agents-remediation.md
+++ b/remediation/fence-agents-remediation/fence-agents-remediation.md
@@ -12,7 +12,7 @@ parent: Remediation
 Generally Available
 {: .label .label-green }
 
-The [Fence Agents Remediation](https://github.com/medik8s/fence-agents-remediation#readme) (FAR) is a Kubernetes operator that uses well-known agents to fence and remediate unhealthy nodes.
+[Fence Agents Remediation](https://github.com/medik8s/fence-agents-remediation#readme) (FAR) is a Kubernetes operator that uses well-known agents to fence and remediate unhealthy nodes.
 The remediation includes rebooting the unhealthy node using a fence agent and then evicting workloads from the unhealthy node.
 
 FAR is available in the Kubernetes community, [OperatorHub.io](https://operatorhub.io/operator/fence-agents-remediation), or it can be installed manually as mentioned in [FAR documentation](https://github.com/medik8s/fence-agents-remediation#installation).

--- a/remediation/fence-agents-remediation/limitations.md
+++ b/remediation/fence-agents-remediation/limitations.md
@@ -10,4 +10,4 @@ nav_order: 3
 # Limitations
 
 1. Currently, FAR supports running a fence agent with only the *reboot* [action](https://github.com/ClusterLabs/fence-agents/blob/main/doc/FenceAgentAPI.md#agent-operations-and-return-values).
-2. The running fence agent inside the FAR pod needs network connectivity to reach the unhealthy node interface, and fence it. In some platforms, the pod isn't granted with this kind of permission.
+2. The fence agent in the FAR pod needs network connectivity to the unhealthy node's management interface. On some platforms, the pod network lacks this kind of connectivity.

--- a/remediation/fence-agents-remediation/limitations.md
+++ b/remediation/fence-agents-remediation/limitations.md
@@ -10,3 +10,4 @@ nav_order: 3
 # Limitations
 
 1. Currently, FAR supports running a fence agent with only the *reboot* [action](https://github.com/ClusterLabs/fence-agents/blob/main/doc/FenceAgentAPI.md#agent-operations-and-return-values).
+2. The running fence agent inside the FAR pod needs network connectivity to reach the unhealthy node interface, and fence it. In some platforms, the pod isn't granted with this kind of permission.


### PR DESCRIPTION
FAR has a network connectivity limitation when the fence agent can't communicate with the unhealthy node interface.
In some platforms, the pod isn't granted this kind of permission for fencing the node.