### PR TITLE
Fix typo in recover_affected_workloads.md

### DIFF
--- a/recover_affected_workloads.md
+++ b/recover_affected_workloads.md
@@ -43,7 +43,7 @@ will be created.
 # Volume recovery flow
 
 Regular volumes attached to pod are ephemeral and don't contain persisted data.
-They are mostly used to mount secretes, config maps, share unix sockets between
+They are mostly used to mount secrets, config maps, share unix sockets between
 components and maybe temporary storage of data. Recovering them is not considered
 an issue.
 Persistent volumes however are the main concern of workload that is lost.


### PR DESCRIPTION
Corrected the spelling of 'secretes' to 'secrets' in the documentation.
#### Why we need this PR
We want people to read the documentation...

#### Changes made
Minor typo fixed

#### Which issue(s) this PR fixes
N/A

#### Test plan
Read the docs again