### PR TITLE
Fix link to NHC's README in GettingStarted.md

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -22,6 +22,6 @@ After few minutes, self-node-remediation will be automatically installed.
 Node Healthcheck Operator includes a dependency on [Self Node Remediation](/remediation/self-node-remediation/self-node-remediation/) with opinionated defaults to be able to function right after installation.
 You may want to tweak the configuration of both, or install one of the [alternatives to Self Node Remediation](/remediation/remediation/#implementations) in order to match your cluster needs.
 
-To tweak NHC's configuration see [NHC's README](https://github.com/medik8s/node-healthcheck-operator/blob/main/docs/README.md)
+To tweak NHC's configuration see [NHC's README](https://github.com/medik8s/node-healthcheck-operator/blob/main/docs/readme.md)
 
 To change the default Self Node Remediation configuration, see [Self Node Remediation Configuration](/remediation/self-node-remediation/configuration) page.


### PR DESCRIPTION
case matters?
clear browser cache, history probably and try the upper case link. Get's 404. who knew ¯\_(ツ)_/¯

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a documentation link in the Getting Started guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->